### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@ name: Go build and test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Tech-Preta/kubecarga/security/code-scanning/1](https://github.com/Tech-Preta/kubecarga/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set `contents: read` as the minimal required permission. This ensures the workflow has only the access it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
